### PR TITLE
CASMPET-5212: use the recent external-dns image

### DIFF
--- a/.github/workflows/charts-lint-test-scan-cron.yml
+++ b/.github/workflows/charts-lint-test-scan-cron.yml
@@ -1,0 +1,16 @@
+name: Cron Lint, test, and scan Helm charts
+on:
+  schedule:
+    - cron: "57 22 * * *"
+  workflow_dispatch:
+jobs:
+  lint-test-scan:
+    uses: Cray-HPE/.github/.github/workflows/charts-lint-test-scan.yml@main
+    with:
+      ct-config: |
+        chart-dirs:
+          - kubernetes
+      scan-chart-snyk-args: "--severity-threshold=high --policy-path=kubernetes/.snyk"
+      scan-image-snyk-args: "--severity-threshold=high"
+    secrets:
+      snyk-token: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/charts-lint-test-scan.yml
+++ b/.github/workflows/charts-lint-test-scan.yml
@@ -1,0 +1,19 @@
+name: Lint, test, and scan Helm charts
+on:
+  pull_request:
+    branches:
+      - master
+      - release/**
+  workflow_dispatch:
+jobs:
+  lint-test-scan:
+    uses: Cray-HPE/.github/.github/workflows/charts-lint-test-scan.yml@main
+    with:
+      lint-charts: ${{ github.event_name == 'pull_request' }}
+      ct-config: |
+        chart-dirs:
+          - kubernetes
+      scan-chart-snyk-args: "--severity-threshold=high --policy-path=kubernetes/.snyk"
+      scan-image-snyk-args: "--severity-threshold=high"
+    secrets:
+      snyk-token: ${{ secrets.SNYK_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-(C) Copyright [2020] Hewlett Packard Enterprise Development LP
+(C) Copyright [2022] Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/kubernetes/cray-externaldns/Chart.yaml
+++ b/kubernetes/cray-externaldns/Chart.yaml
@@ -1,13 +1,16 @@
-apiVersion: v1
-appVersion: 1.5.2
+apiVersion: v2
+version: 1.4.0
+name: cray-externaldns
 description: Support for DNS outside kubernets LoadBalancers and Annotation-based
 keywords:
-- coredns
-- dns
-- externaldns
-icon: https://raw.githubusercontent.com/coredns/logo/master/Icon/CoreDNS_Colour_Icon.svg
+  - dns
+  - externaldns
+maintainers:
+  - name: bo-quan
+icon: https://bitnami.com/assets/stacks/external-dns/img/external-dns-stack-220x234.png
 sources:
-- https://github.com/coredns/coredns
-- https://github.com/kubernetes-incubator/external-dns
-name: cray-externaldns
-version: 1.0.0 
+  - https://github.com/kubernetes-sigs/external-dns
+  - https://github.com/Cray-HPE/cray-externaldns
+appVersion: 0.10.2
+annotations:
+  artifacthub.io/license: MIT

--- a/kubernetes/cray-externaldns/requirements.lock
+++ b/kubernetes/cray-externaldns/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: external-dns
-  repository: https://charts.bitnami.com/bitnami
-  version: 5.1.3
-digest: sha256:6e19395fc032033cf70fb4af4088ff9efc193daf17f7c380ca493c5d305db38b
-generated: "2021-07-01T08:43:40.59919019Z"

--- a/kubernetes/cray-externaldns/requirements.yaml
+++ b/kubernetes/cray-externaldns/requirements.yaml
@@ -1,5 +1,0 @@
----
-dependencies:
-  - name: external-dns
-    version: 5.1.3
-    repository: https://charts.bitnami.com/bitnami

--- a/kubernetes/cray-externaldns/values.yaml
+++ b/kubernetes/cray-externaldns/values.yaml
@@ -4,9 +4,9 @@
 
 external-dns:
   image:
-    registry: docker.io
-    repository: bitnami/external-dns
-    tag: 0.5.16-debian-9-r8
+    registry: artifactory.algol60.net
+    repository: csm-docker/stable/docker.io/bitnami/external-dns/0/debian-10
+    tag: 0.10.2-debian-10-r23
   podAnnotations:
     # Disable istio sidecar since etcd doesn't use it.
     sidecar.istio.io/inject: "false"


### PR DESCRIPTION
## Summary and Scope

Use the latest external-dns container image with less critical and high CVEs (reduced from 31 to 13)

## Issues and Related PRs

* Resolves [CASMPET-5212]

## Testing

### Tested on:

  * `wasp`

### Test description:

Chris redeployed powerdns and the external-dns chart, and made sure that powerdns records were 
repopulated correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low. We can always back off the change if unexpected issues arise.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

