### PR TITLE
CASMINST-4085: use the updated image path

### DIFF
--- a/kubernetes/cray-externaldns/Chart.yaml
+++ b/kubernetes/cray-externaldns/Chart.yaml
@@ -1,5 +1,28 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 apiVersion: v2
-version: 1.4.0
+version: 1.4.1
 name: cray-externaldns
 description: Support for DNS outside kubernets LoadBalancers and Annotation-based
 keywords:

--- a/kubernetes/cray-externaldns/values.yaml
+++ b/kubernetes/cray-externaldns/values.yaml
@@ -1,11 +1,30 @@
-# Default values for cray-externaldns.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 external-dns:
   image:
     registry: artifactory.algol60.net
-    repository: csm-docker/stable/docker.io/bitnami/external-dns/0/debian-10
+    repository: csm-docker/stable/docker.io/bitnami/external-dns
     tag: 0.10.2-debian-10-r23
   podAnnotations:
     # Disable istio sidecar since etcd doesn't use it.


### PR DESCRIPTION
## Summary and Scope

Change the image path of externaldns to the one consistent with other image paths.

## Issues and Related PRs

* Resolves [CASMINST-4085]

## Testing

### Tested on:

  * `mug`

### Test description:

Upgraded the external-dns chart and restarted cray-dns-powerdns and cray-powerdns-manager deployments, and verified that no errors in pod logs and powerdns records are correct:

ncn-m001:~/bquan # kubectl -n services exec -it cray-dns-powerdns-84dd665566-qd8r8  -- sh -c 'pdnsutil list-zone nmn.mug.dev.cray.com' | head
Defaulting container name to cray-dns-powerdns.
Use 'kubectl describe pod/cray-dns-powerdns-84dd665566-qd8r8 -n services' to see all of the containers in this pod.
$ORIGIN .
kubeapi-vip.nmn.mug.dev.cray.com	3600	IN	A	10.252.1.2
ncn-m001.nmn.mug.dev.cray.com	3600	IN	CNAME	x3000c0s1b0n0.nmn.mug.dev.cray.com.
ncn-m001-nmn.nmn.mug.dev.cray.com	3600	IN	CNAME	x3000c0s1b0n0.nmn.mug.dev.cray.com.
ncn-m002.nmn.mug.dev.cray.com	3600	IN	CNAME	x3000c0s3b0n0.nmn.mug.dev.cray.com.
ncn-m002-nmn.nmn.mug.dev.cray.com	3600	IN	CNAME	x3000c0s3b0n0.nmn.mug.dev.cray.com.
ncn-m003.nmn.mug.dev.cray.com	3600	IN	CNAME	x3000c0s5b0n0.nmn.mug.dev.cray.com.
ncn-m003-nmn.nmn.mug.dev.cray.com	3600	IN	CNAME	x3000c0s5b0n0.nmn.mug.dev.cray.com.
ncn-s001.nmn.mug.dev.cray.com	3600	IN	CNAME	x3000c0s13b0n0.nmn.mug.dev.cray.com.
ncn-s001-nmn.nmn.mug.dev.cray.com	3600	IN	CNAME	x3000c0s13b0n0.nmn.mug.dev.cray.com.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low. The same image is used, the PR only changes the image path where we put the externaldns image.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

