### PR TITLE
CASMPET-6554: use external-dns image 0.13.5

### DIFF
--- a/kubernetes/cray-externaldns/Chart.yaml
+++ b/kubernetes/cray-externaldns/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.4.1
+version: 1.5.0
 name: cray-externaldns
 description: Support for DNS outside kubernets LoadBalancers and Annotation-based
 keywords:
@@ -31,7 +31,7 @@ keywords:
 dependencies:
   - name: external-dns
     repository: https://charts.bitnami.com/bitnami
-    version: 6.1.0
+    version: 6.20.4
 maintainers:
   - name: bo-quan
 home: https://github.com/Cray-HPE/cray-externaldns
@@ -39,6 +39,6 @@ icon: https://bitnami.com/assets/stacks/external-dns/img/external-dns-stack-220x
 sources:
   - https://github.com/kubernetes-sigs/external-dns
   - https://github.com/Cray-HPE/cray-externaldns
-appVersion: 0.10.2
+appVersion: 0.13.4
 annotations:
   artifacthub.io/license: MIT

--- a/kubernetes/cray-externaldns/values.yaml
+++ b/kubernetes/cray-externaldns/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,7 @@ external-dns:
   image:
     registry: artifactory.algol60.net
     repository: csm-docker/stable/docker.io/bitnami/external-dns
-    tag: 0.10.2-debian-10-r23
+    tag: 0.13.5
   podAnnotations:
     # Disable istio sidecar since etcd doesn't use it.
     sidecar.istio.io/inject: "false"


### PR DESCRIPTION
## Summary and Scope

Use the latest 0.13.5 external-dns image in the chart for CVE remediation (no known critical or high CVE issues in the 0.13.5 image.)

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6554](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6554)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `ashton`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_
Upgraded cray-externaldns chart in ashton, found no errors in log files and Chris verified that it works fine with the new cray-powerdns-manager chart.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

