### PR TITLE
CASMPET-7332: Disable PSP by setting pspEnabled to false

### DIFF
--- a/kubernetes/cray-externaldns/Chart.yaml
+++ b/kubernetes/cray-externaldns/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.6.0
+version: 1.6.1
 name: cray-externaldns
 description: Support for DNS outside kubernets LoadBalancers and Annotation-based
 keywords:

--- a/kubernetes/cray-externaldns/values.yaml
+++ b/kubernetes/cray-externaldns/values.yaml
@@ -32,7 +32,7 @@ external-dns:
   rbac:
     # If true, create & use RBAC resources
     create: true
-    pspEnabled: true
+    pspEnabled: false
   sources:
     - "service"
     - "istio-gateway"


### PR DESCRIPTION
## Summary and Scope

PSP is not supported in K8s 1.25+ so disabling for CSM 1.7.

## Issues and Related PRs

* Resolves [CASMPET-7332](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7332)

## Testing
Install on `beau` running K8s 1.24 and on `molly` running K8s 1.32.

On `molly` running K8s 1.32.2:
```
pit:~/studenym # helm upgrade -n services cray-externaldns cray-externaldns-1.6.1-20250313130232+f07f4d4.tgz
Release "cray-externaldns" has been upgraded. Happy Helming!
NAME: cray-externaldns
LAST DEPLOYED: Thu Mar 13 16:12:23 2025
NAMESPACE: services
STATUS: deployed
REVISION: 5
TEST SUITE: None
NOTES:
Happy Helming
pit:~/studenym #
pit:~/studenym # kubectl get pods -n services | grep external
cray-externaldns-external-dns-7cbc88795d-w5qvr                    1/1     Running            0                 2m13s
pit:~/studenym # kubectl get pods -n services cray-externaldns-external-dns-7cbc88795d-w5qvr -o yaml | grep image
    image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/external-dns:0.15.0
    imagePullPolicy: IfNotPresent
    image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/external-dns:0.15.0
    imageID: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/external-dns@sha256:d909ec61396b69b83025bde15e76daf9724db8f30d21e7597959c84fce862160
pit:~/studenym #
```

On `beau` running K8s 1.24.17:
```
pit:~ # kubectl version --short
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
Client Version: v1.24.17
Kustomize Version: v4.5.4
Server Version: v1.24.17
pit:~ #
pit:~/studenym # helm upgrade -n services cray-externaldns cray-externaldns-1.6.1-20250313130232+f07f4d4.tgz
W0313 20:20:14.672735   27607 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0313 20:20:14.696889   27607 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
Release "cray-externaldns" has been upgraded. Happy Helming!
NAME: cray-externaldns
LAST DEPLOYED: Thu Mar 13 20:20:13 2025
NAMESPACE: services
STATUS: deployed
REVISION: 5
TEST SUITE: None
NOTES:
Happy Helming
pit:~/studenym # helm history -n services cray-externaldns
REVISION	UPDATED                 	STATUS    	CHART                                        	APP VERSION	DESCRIPTION
1       	Thu Mar 13 17:55:22 2025	superseded	cray-externaldns-1.5.0                       	0.13.4     	Install complete
2       	Thu Mar 13 20:07:13 2025	superseded	cray-externaldns-1.6.0                       	0.15.0     	Upgrade complete
3       	Thu Mar 13 20:15:52 2025	superseded	cray-externaldns-1.6.1-20250313130232+f07f4d4	0.15.0     	Upgrade complete
4       	Thu Mar 13 20:18:31 2025	superseded	cray-externaldns-1.5.0                       	0.13.4     	Rollback to 1
5       	Thu Mar 13 20:20:13 2025	deployed  	cray-externaldns-1.6.1-20250313130232+f07f4d4	0.15.0     	Upgrade complete
pit:~/studenym #
pit:~ # kubectl get pods -n services | grep external
cray-externaldns-external-dns-6b5475f55-4qjm6                     1/1     Running            0                17s
pit:~ # kubectl get pods -n services cray-externaldns-external-dns-6b5475f55-4qjm6 -o yaml | grep image
    image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/external-dns:0.15.0
    imagePullPolicy: IfNotPresent
    image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/external-dns:0.15.0
    imageID: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/external-dns@sha256:d909ec61396b69b83025bde15e76daf9724db8f30d21e7597959c84fce862160
pit:~ #
```

## Risks and Mitigations


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

