### PR TITLE
CASMPET-7477: Upgrade external-dns image to 0.17.0

### DIFF
--- a/kubernetes/cray-externaldns/Chart.yaml
+++ b/kubernetes/cray-externaldns/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.6.1
+version: 1.7.0
 name: cray-externaldns
 description: Support for DNS outside kubernets LoadBalancers and Annotation-based
 keywords:
@@ -39,6 +39,6 @@ icon: https://bitnami.com/assets/stacks/external-dns/img/external-dns-stack-220x
 sources:
   - https://github.com/kubernetes-sigs/external-dns
   - https://github.com/Cray-HPE/cray-externaldns
-appVersion: 0.15.0
+appVersion: 0.17.0
 annotations:
   artifacthub.io/license: MIT

--- a/kubernetes/cray-externaldns/values.yaml
+++ b/kubernetes/cray-externaldns/values.yaml
@@ -25,7 +25,7 @@ external-dns:
   image:
     registry: artifactory.algol60.net
     repository: csm-docker/stable/docker.io/bitnami/external-dns
-    tag: 0.15.0
+    tag: 0.17.0
   podAnnotations:
     # Disable istio sidecar since etcd doesn't use it.
     sidecar.istio.io/inject: "false"


### PR DESCRIPTION
## Summary and Scope
Upgrade `bitnami/external-dns` to 0.17.0 to, hopefully, lessen the number of critical and high severity CVEs.

## Issues and Related PRs
* Resolves [CASMPET-7477](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7477)

## Testing
Tested chart upgrade on both `beau` and `wasp`.
```
ncn-m001:~/studenym # helm upgrade -n services cray-externaldns cray-externaldns-1.7.0-20250902195940+e254cda.tgz
Release "cray-externaldns" has been upgraded. Happy Helming!
NAME: cray-externaldns
LAST DEPLOYED: Wed Sep  3 17:45:50 2025
NAMESPACE: services
STATUS: deployed
REVISION: 4
TEST SUITE: None
NOTES:
Happy Helming
ncn-m001:~/studenym # kubectl get pods -n services | grep external-dns
cray-externaldns-external-dns-59ff97c45f-wvwzd                    1/1     Running     0             2m7s
ncn-m001:~/studenym # kubectl get pod -n services cray-externaldns-external-dns-59ff97c45f-wvwzd -o yaml | grep image
    image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/external-dns:0.17.0
    imagePullPolicy: IfNotPresent
    image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/external-dns:0.17.0
    imageID: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/external-dns@sha256:d04f1408247f611e4a64fab59f74b4aa50d06a22f82b95b6c8229b7f17bb2795
```

Tested basic functionality on `wasp`
```
ncn-m001:~/studenym # kubectl exec -it -n services deployment/cray-dns-powerdns -- sh
/ $ pdnsutil list-all-zones
wasp.hpc.amslabs.hpecorp.net
mtl
cmn
nmn
nmnlb
hmn
hmnlb
hsn.wasp.hpc.amslabs.hpecorp.net
hsn
chn
106.10.in-addr.arpa
107.10.in-addr.arpa
250.10.in-addr.arpa
100.92.10.in-addr.arpa
100.94.10.in-addr.arpa
mtl.wasp.hpc.amslabs.hpecorp.net
cmn.wasp.hpc.amslabs.hpecorp.net
hmn.wasp.hpc.amslabs.hpecorp.net
nmnlb.wasp.hpc.amslabs.hpecorp.net
hmnlb.wasp.hpc.amslabs.hpecorp.net
chn.wasp.hpc.amslabs.hpecorp.net
nmn.wasp.hpc.amslabs.hpecorp.net
252.10.in-addr.arpa
1.10.in-addr.arpa
254.10.in-addr.arpa
167.102.10.in-addr.arpa
/ $ pdnsutil list-zone cmn.wasp.hpc.amslabs.hpecorp.net | grep nexus
a-nexus.cmn.wasp.hpc.amslabs.hpecorp.net	300	IN	TXT	"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/istio-system/istio-ingressgateway-cmn"
nexus.cmn.wasp.hpc.amslabs.hpecorp.net	300	IN	A	10.102.167.64
nexus.cmn.wasp.hpc.amslabs.hpecorp.net	300	IN	TXT	"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/istio-system/istio-ingressgateway-cmn"
/ $ pdnsutil list-zone cmn.wasp.hpc.amslabs.hpecorp.net | grep nexus.cmn
a-nexus.cmn.wasp.hpc.amslabs.hpecorp.net	300	IN	TXT	"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/istio-system/istio-ingressgateway-cmn"
nexus.cmn.wasp.hpc.amslabs.hpecorp.net	300	IN	A	10.102.167.64
nexus.cmn.wasp.hpc.amslabs.hpecorp.net	300	IN	TXT	"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/istio-system/istio-ingressgateway-cmn"
/ $ pdnsutil delete-zone cmn.wasp.hpc.amslabs.hpecorp.net
/ $ pdnsutil list-zone cmn.wasp.hpc.amslabs.hpecorp.net | grep nexus.cmn
Zone 'cmn.wasp.hpc.amslabs.hpecorp.net' not found!
/ $ pdnsutil list-zone cmn.wasp.hpc.amslabs.hpecorp.net | grep nexus.cmn
Zone 'cmn.wasp.hpc.amslabs.hpecorp.net' not found!
/ $ pdnsutil list-zone cmn.wasp.hpc.amslabs.hpecorp.net | grep nexus.cmn
/ $ pdnsutil list-zone cmn.wasp.hpc.amslabs.hpecorp.net | grep nexus.cmn
/ $ pdnsutil list-zone cmn.wasp.hpc.amslabs.hpecorp.net | grep nexus.cmn
a-nexus.cmn.wasp.hpc.amslabs.hpecorp.net	300	IN	TXT	"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/istio-system/istio-ingressgateway-cmn"
nexus.cmn.wasp.hpc.amslabs.hpecorp.net	300	IN	A	10.102.167.64
nexus.cmn.wasp.hpc.amslabs.hpecorp.net	300	IN	TXT	"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/istio-system/istio-ingressgateway-cmn"
/ $ exit
```

## Risks and Mitigations
Low risk.  0.17.0 doesn't have any documented breaking changes.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

